### PR TITLE
moving attachToAdjacent method to onDetach()

### DIFF
--- a/app/src/main/java/com/damageddev/myotaskerplugin/services/BackgroundService.java
+++ b/app/src/main/java/com/damageddev/myotaskerplugin/services/BackgroundService.java
@@ -83,7 +83,6 @@ public final class BackgroundService extends Service {
 
         @Override
         public void onDisconnect(Myo myo, long timestamp) {
-            mHub.attachToAdjacentMyo();
 
             SharedPreferences sharedPreferences = getSharedPreferences(Constants.SHARED_PREFERENCES_NAME, Context.MODE_MULTI_PROCESS);
 
@@ -148,6 +147,8 @@ public final class BackgroundService extends Service {
         @Override
         public void onDetach(Myo myo, long timestamp) {
             super.onDetach(myo, timestamp);
+
+            mHub.attachToAdjacentMyo();
 
             SharedPreferences sharedPreferences = getSharedPreferences(Constants.SHARED_PREFERENCES_NAME, Context.MODE_MULTI_PROCESS);
 


### PR DESCRIPTION
Note that, if a Myo is already attached, the Myo SDK will attempt to reconnect automatically if there are disconnections. Also, if the attachToAdjacentMyo() function is called multiple times (with attached Myos) it can cause issues with other BT devices currently connected to the phone. This is currently being revised in the Myo SDK documentation as well.

In this case, I have made the assumption that we would like to be able to attachtoAdjacentMyo() as soon as the previous one has been detached. 
